### PR TITLE
fix namespace definition if two accelerators are selected

### DIFF
--- a/include/cupla/defines.hpp
+++ b/include/cupla/defines.hpp
@@ -1,0 +1,102 @@
+/* Copyright 2016 Rene Widera
+ *
+ * This file is part of cupla.
+ *
+ * cupla is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * cupla is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with cupla.
+ * If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#pragma once
+
+#include <alpaka/alpaka.hpp>
+#include <cstdint>
+
+#include "cupla/namespace.hpp"
+
+#ifdef ALPAKA_ACC_CPU_B_SEQ_T_OMP2_ENABLED
+#   undef ALPAKA_ACC_CPU_B_SEQ_T_OMP2_ENABLED
+#   define ALPAKA_ACC_CPU_B_SEQ_T_OMP2_ENABLED 1
+#endif
+
+#ifdef ALPAKA_ACC_CPU_B_SEQ_T_THREADS_ENABLED
+#   undef ALPAKA_ACC_CPU_B_SEQ_T_THREADS_ENABLED
+#   define ALPAKA_ACC_CPU_B_SEQ_T_THREADS_ENABLED 1
+#endif
+
+#ifdef ALPAKA_ACC_CPU_B_OMP2_T_SEQ_ENABLED
+#   undef ALPAKA_ACC_CPU_B_OMP2_T_SEQ_ENABLED
+#   define ALPAKA_ACC_CPU_B_OMP2_T_SEQ_ENABLED 1
+#endif
+
+#ifdef ALPAKA_ACC_GPU_CUDA_ENABLED
+#   undef ALPAKA_ACC_GPU_CUDA_ENABLED
+#   define ALPAKA_ACC_GPU_CUDA_ENABLED 1
+#endif
+
+#ifdef ALPAKA_ACC_CPU_B_SEQ_T_SEQ_ENABLED
+#   undef ALPAKA_ACC_CPU_B_SEQ_T_SEQ_ENABLED
+#   define ALPAKA_ACC_CPU_B_SEQ_T_SEQ_ENABLED 1
+#endif
+
+#ifdef ALPAKA_ACC_CPU_B_TBB_T_SEQ_ENABLED
+#   undef ALPAKA_ACC_CPU_B_TBB_T_SEQ_ENABLED
+#   define ALPAKA_ACC_CPU_B_TBB_T_SEQ_ENABLED 1
+#endif
+
+#ifdef ALPAKA_ACC_GPU_HIP_ENABLED
+#   undef ALPAKA_ACC_GPU_HIP_ENABLED
+#   define ALPAKA_ACC_GPU_HIP_ENABLED 1
+#endif
+
+#define CUPLA_NUM_SELECTED_DEVICES (                                           \
+        ALPAKA_ACC_CPU_B_SEQ_T_OMP2_ENABLED +                                  \
+        ALPAKA_ACC_CPU_B_SEQ_T_THREADS_ENABLED +                               \
+        ALPAKA_ACC_CPU_B_OMP2_T_SEQ_ENABLED  +                                 \
+        ALPAKA_ACC_GPU_CUDA_ENABLED +                                          \
+        ALPAKA_ACC_CPU_B_SEQ_T_SEQ_ENABLED +                                   \
+        ALPAKA_ACC_CPU_B_TBB_T_SEQ_ENABLED +                                   \
+        ALPAKA_ACC_GPU_HIP_ENABLED                                             \
+)
+
+
+#if( CUPLA_NUM_SELECTED_DEVICES == 0 )
+    #error "there is no accelerator selected, please run `ccmake .` and select one"
+#endif
+
+#if( CUPLA_NUM_SELECTED_DEVICES > 2  )
+    #error "please select at most two accelerators"
+#endif
+
+// count accelerators where the thread count must be one
+#define CUPLA_NUM_SELECTED_THREAD_SEQ_DEVICES (                                \
+        ALPAKA_ACC_CPU_B_OMP2_T_SEQ_ENABLED +                                  \
+        ALPAKA_ACC_CPU_B_SEQ_T_SEQ_ENABLED +                                   \
+        ALPAKA_ACC_CPU_B_TBB_T_SEQ_ENABLED                                     \
+)
+
+#define CUPLA_NUM_SELECTED_THREAD_PARALLEL_DEVICES (                           \
+        ALPAKA_ACC_CPU_B_SEQ_T_OMP2_ENABLED +                                  \
+        ALPAKA_ACC_CPU_B_SEQ_T_THREADS_ENABLED +                               \
+        ALPAKA_ACC_GPU_CUDA_ENABLED +                                          \
+        ALPAKA_ACC_GPU_HIP_ENABLED                                             \
+)
+
+#if( CUPLA_NUM_SELECTED_THREAD_SEQ_DEVICES > 1 )
+    #error "it is only alowed to select one thread sequential Alpaka accelerator"
+#endif
+
+#if( CUPLA_NUM_SELECTED_THREAD_PARALLEL_DEVICES > 1 )
+    #error "it is only alowed to select one thread parallelized Alpaka accelerator"
+#endif

--- a/include/cupla/namespace.hpp
+++ b/include/cupla/namespace.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2019 Andrea Bocci
+/* Copyright 2019 Andrea Bocci, Rene Widera
  *
  * This file is part of cupla.
  *
@@ -18,60 +18,76 @@
  *
  */
 
-
 #pragma once
+
+#include "cupla/defines.hpp"
+
 
 #if CUPLA_STREAM_ASYNC_ENABLED
 
-#ifdef ALPAKA_ACC_CPU_B_SEQ_T_OMP2_ENABLED
-#define CUPLA_ACCELERATOR_NAMESPACE cupla_seq_omp2_async
-#endif
+// thread parallel and thread sequential accelerator is used together
+#   if(CUPLA_NUM_SELECTED_THREAD_SEQ_DEVICES == 1 && CUPLA_NUM_SELECTED_THREAD_PARALLEL_DEVICES == 1)
+#       define CUPLA_ACCELERATOR_NAMESPACE cupla_mixed_async
+#   else
 
-#ifdef ALPAKA_ACC_CPU_B_SEQ_T_THREADS_ENABLED
-#define CUPLA_ACCELERATOR_NAMESPACE cupla_seq_threads_async
-#endif
+#       ifdef ALPAKA_ACC_CPU_B_SEQ_T_OMP2_ENABLED
+#           define CUPLA_ACCELERATOR_NAMESPACE cupla_seq_omp2_async
+#       endif
 
-#ifdef ALPAKA_ACC_CPU_B_OMP2_T_SEQ_ENABLED
-#define CUPLA_ACCELERATOR_NAMESPACE cupla_omp2_seq_async
-#endif
+#       ifdef ALPAKA_ACC_CPU_B_SEQ_T_THREADS_ENABLED
+#           define CUPLA_ACCELERATOR_NAMESPACE cupla_seq_threads_async
+#       endif
 
-#ifdef ALPAKA_ACC_GPU_CUDA_ENABLED
-#define CUPLA_ACCELERATOR_NAMESPACE cupla_cuda_async
-#endif
+#       ifdef ALPAKA_ACC_CPU_B_OMP2_T_SEQ_ENABLED
+#           define CUPLA_ACCELERATOR_NAMESPACE cupla_omp2_seq_async
+#       endif
 
-#ifdef ALPAKA_ACC_CPU_B_SEQ_T_SEQ_ENABLED
-#define CUPLA_ACCELERATOR_NAMESPACE cupla_seq_seq_async
-#endif
+#       ifdef ALPAKA_ACC_GPU_CUDA_ENABLED
+#           define CUPLA_ACCELERATOR_NAMESPACE cupla_cuda_async
+#       endif
 
-#ifdef ALPAKA_ACC_CPU_B_TBB_T_SEQ_ENABLED
-#define CUPLA_ACCELERATOR_NAMESPACE cupla_tbb_seq_async
-#endif
+#       ifdef ALPAKA_ACC_CPU_B_SEQ_T_SEQ_ENABLED
+#           define CUPLA_ACCELERATOR_NAMESPACE cupla_seq_seq_async
+#       endif
+
+#       ifdef ALPAKA_ACC_CPU_B_TBB_T_SEQ_ENABLED
+#           define CUPLA_ACCELERATOR_NAMESPACE cupla_tbb_seq_async
+#       endif
+
+#   endif // mixed accelerator usage
 
 #else // CUPLA_STREAM_ASYNC_ENABLED
 
-#ifdef ALPAKA_ACC_CPU_B_SEQ_T_OMP2_ENABLED
-#define CUPLA_ACCELERATOR_NAMESPACE cupla_seq_omp2_sync
-#endif
+// thread parallel and thread sequential accelerator is used together
+#   if(CUPLA_NUM_SELECTED_THREAD_SEQ_DEVICES == 1 && CUPLA_NUM_SELECTED_THREAD_PARALLEL_DEVICES == 1)
+#       define CUPLA_ACCELERATOR_NAMESPACE cupla_mixed_sync
+#   else
 
-#ifdef ALPAKA_ACC_CPU_B_SEQ_T_THREADS_ENABLED
-#define CUPLA_ACCELERATOR_NAMESPACE cupla_seq_threads_sync
-#endif
+#       ifdef ALPAKA_ACC_CPU_B_SEQ_T_OMP2_ENABLED
+#           define CUPLA_ACCELERATOR_NAMESPACE cupla_seq_omp2_sync
+#       endif
 
-#ifdef ALPAKA_ACC_CPU_B_OMP2_T_SEQ_ENABLED
-#define CUPLA_ACCELERATOR_NAMESPACE cupla_omp2_seq_sync
-#endif
+#       ifdef ALPAKA_ACC_CPU_B_SEQ_T_THREADS_ENABLED
+#           define CUPLA_ACCELERATOR_NAMESPACE cupla_seq_threads_sync
+#       endif
 
-#ifdef ALPAKA_ACC_GPU_CUDA_ENABLED
-#define CUPLA_ACCELERATOR_NAMESPACE cupla_cuda_sync
-#endif
+#       ifdef ALPAKA_ACC_CPU_B_OMP2_T_SEQ_ENABLED
+#           define CUPLA_ACCELERATOR_NAMESPACE cupla_omp2_seq_sync
+#       endif
 
-#ifdef ALPAKA_ACC_CPU_B_SEQ_T_SEQ_ENABLED
-#define CUPLA_ACCELERATOR_NAMESPACE cupla_seq_seq_sync
-#endif
+#       ifdef ALPAKA_ACC_GPU_CUDA_ENABLED
+#           define CUPLA_ACCELERATOR_NAMESPACE cupla_cuda_sync
+#       endif
 
-#ifdef ALPAKA_ACC_CPU_B_TBB_T_SEQ_ENABLED
-#define CUPLA_ACCELERATOR_NAMESPACE cupla_tbb_seq_sync
-#endif
+#       ifdef ALPAKA_ACC_CPU_B_SEQ_T_SEQ_ENABLED
+#           define CUPLA_ACCELERATOR_NAMESPACE cupla_seq_seq_sync
+#       endif
+
+#       ifdef ALPAKA_ACC_CPU_B_TBB_T_SEQ_ENABLED
+#           define CUPLA_ACCELERATOR_NAMESPACE cupla_tbb_seq_sync
+#       endif
+
+#   endif // mixed accelerator usage
 
 #endif // CUPLA_STREAM_ASYNC_ENABLED
 

--- a/include/cupla/types.hpp
+++ b/include/cupla/types.hpp
@@ -23,8 +23,9 @@
 
 #include <alpaka/alpaka.hpp>
 #include <cstdint>
-
+#include "cupla/defines.hpp"
 #include "cupla/namespace.hpp"
+
 
 #ifdef ALPAKA_ACC_CPU_B_SEQ_T_OMP2_ENABLED
 #   undef ALPAKA_ACC_CPU_B_SEQ_T_OMP2_ENABLED


### PR DESCRIPTION
- move preprocessor definitions from types.hpp to defines.hpp
- indroduce the namespace anme `cupla_mixed_sync` and `cupla_mixed_async` for special case where two accelerators are selected

allow: `cmake ..//example/CUDASamples/matrixMul/ -DALPAKA_ACC_CPU_B_SEQ_T_SEQ_ENABLE=ON -DALPAKA_ACC_CPU_B_SEQ_T_OMP2_ENABLE=ON`